### PR TITLE
Change splash page buttons

### DIFF
--- a/frontend/components/splash_page/splash_nav_bar.jsx
+++ b/frontend/components/splash_page/splash_nav_bar.jsx
@@ -4,17 +4,6 @@ import { Link } from 'react-router-dom';
 const SplashNavBar = ({ currentUser, logout, openModal }) => {
   return (
     <div className = "main-nav-bar">
-
-      {/* <div className = "main-nav-bar-discordicon">
-        <Link to="/">
-          <img 
-            src={window.discordiconbackground}
-            alt="discord-icon-background"
-            id="main-nav-bar-discordiconbackground"
-          />
-        </Link>
-      </div> */}
-
       <div className = "main-nav-bar-middle">
         <a href="https://www.linkedin.com/in/lucidlaughter/">
           <img 

--- a/frontend/components/splash_page/welcome_nav_bar.jsx
+++ b/frontend/components/splash_page/welcome_nav_bar.jsx
@@ -1,21 +1,27 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-const WelcomeNavBar = ({ openModal }) => {
+const WelcomeNavBar = () => {
+
+  // reminder: there are still login, demo, and signup modals in the file tree
+  // they were removed and changed to link to the login/signup pages instead for a cleaner user experience
+  
   return (
     <div
       className = "welcome-nav-bar-login-signup-links"
     >
       <nav className="login-signup">
-        <button
-          id="welcome-login-button"
-          onClick={() => openModal('login')}
-        >LOGIN</button>
+        <Link to="login">
+          <button
+            id="welcome-login-button"
+          >LOGIN</button>
+        </Link>
 
-        <button
-          id="welcome-signup-button"
-          onClick={() => openModal('signup')}
-        >SIGNUP</button>
+        <Link to="register">
+          <button
+            id="welcome-signup-button"
+          >SIGNUP</button>  
+        </Link>
       </nav>
     </div>
   )

--- a/frontend/components/splash_page/welcome_nav_bar.jsx
+++ b/frontend/components/splash_page/welcome_nav_bar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
 
-const WelcomeNavBar = ({ currentUser, logout, openModal }) => {
+const WelcomeNavBar = ({ openModal }) => {
   return (
     <div
       className = "welcome-nav-bar-login-signup-links"
@@ -11,11 +11,6 @@ const WelcomeNavBar = ({ currentUser, logout, openModal }) => {
           id="welcome-login-button"
           onClick={() => openModal('login')}
         >LOGIN</button>
-
-        <button
-          id="welcome-demo-button"
-          onClick={() => openModal('demo-login')}
-        >TRY DEMO</button>
 
         <button
           id="welcome-signup-button"


### PR DESCRIPTION
Previously, buttons on the splash page 'nav bar' were separate modals that allowed a user to login/signup/try demo. Now, they link to their respective login/signup pages for a cleaner user experience.